### PR TITLE
Apply suggestions from zizmor static analysis tool

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,8 +23,10 @@ jobs:
           - beta
           - nightly
     steps:
-      - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@master
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@a54c7afa936fefeb4456b2dd8068152669aa8203
         with:
           components: clippy, rustfmt
           toolchain: ${{ matrix.toolchain }}
@@ -44,8 +46,10 @@ jobs:
     name: clippy doctests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@master
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@a54c7afa936fefeb4456b2dd8068152669aa8203
         with:
           components: clippy
           toolchain: nightly


### PR DESCRIPTION
This applys the suggestions about our gh workflow from the static analysis tool called [zizmor](https://github.com/woodruffw/zizmor), which is meant to find (security-related) issues in github workflows, such as code injection or token stealing by creation of malicious pr's